### PR TITLE
fix ExoPlayback to work with exo 2.4.3 when it really is 2.4.3

### DIFF
--- a/android/src/main/java/guichaguri/trackplayer/player/players/ExoPlayback.java
+++ b/android/src/main/java/guichaguri/trackplayer/player/players/ExoPlayback.java
@@ -101,11 +101,11 @@ public class ExoPlayback extends Playback implements EventListener, IcyHttpDataS
         IcyHttpDataSourceFactory factory = new IcyHttpDataSourceFactory.Builder(Util.getUserAgent(context, "Futuri"))
                 .setIcyHeadersListener(null)
                 .setIcyMetadataChangeListener(this).build();
-        DefaultDataSourceFactory datasourceFactory = new DefaultDataSourceFactory(context, null, factory);
+        // DefaultDataSourceFactory datasourceFactory = new DefaultDataSourceFactory(context, null, factory);
 
-        ExtractorMediaSource mediaSource = new ExtractorMediaSource.Factory(datasourceFactory)
-                .setExtractorsFactory(new DefaultExtractorsFactory())
-                .createMediaSource(url);
+        // ExtractorMediaSource mediaSource = new ExtractorMediaSource.Factory(datasourceFactory)
+        //         .setExtractorsFactory(new DefaultExtractorsFactory())
+        //         .createMediaSource(url);
 
         MediaSource source;
 
@@ -261,10 +261,10 @@ public class ExoPlayback extends Playback implements EventListener, IcyHttpDataS
         }
     }
 
-    @Override
-    public void onSeekProcessed() {
+    // @Override
+    // public void onSeekProcessed() {
 
-    }
+    // }
 
     @Override
     public void onPlayerError(ExoPlaybackException error) {
@@ -275,19 +275,19 @@ public class ExoPlayback extends Playback implements EventListener, IcyHttpDataS
     }
 
     @Override
-    public void onPositionDiscontinuity(int reason) {
+    public void onPositionDiscontinuity() {
 
     }
 
-    @Override
-    public void onShuffleModeEnabledChanged(boolean enabled) {
+    // @Override
+    // public void onShuffleModeEnabledChanged(boolean enabled) {
 
-    }
+    // }
 
-    @Override
-    public void onRepeatModeChanged(int mode) {
+    // @Override
+    // public void onRepeatModeChanged(int mode) {
 
-    }
+    // }
 
     @Override
     public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {


### PR DESCRIPTION
We had conflicting exoplayer dependencies which led to portions of the dexed exo being exo 2.7, and other portions being 2.4. This caused exceptions when attempting to play HLS. Forcing 2.4.3 in gradle fixes this.
 
I'm worried that dscx's work around stream metadata could have inadvertently relied on on the mixed versions. I had to comment and alter some of ExoPlayback.java back to implementing the 2.4.3 version of EventListener interface. There are no build errors in his version of IcyStreamMeta.java and I have tested this at least plays an icy stream, but I have not tested the metadata fully.
